### PR TITLE
Fix bug introduced by previous version 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file contains all notable changes to this project.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.2.2] - 2021-05-11
+
+- Fix bug introduced by v1.2.0 where `has_many` removed the chance to pass extra parameters.
+
 ## [1.2.1] - 2021-05-10
 
 - Some endpoints like `deals/:id/products` allow to expand the response with `include_product_data` that include an attr `product` with all the data - including the custon fields - of the products. The deafult for that option is `false` or `0`. I personally think this is redundant, so this version overrides this behavior by passing `true` or `1` and deleging the attr `product` by merging its content with the body itself, at the end `/products` should return `products`. On future versions this option would be passed to the `has_many` method, like `has_many :products, class_name: "Product", include_data: false`

--- a/lib/pipedrive/resource.rb
+++ b/lib/pipedrive/resource.rb
@@ -73,8 +73,10 @@ module Pipedrive
       options = { "include_#{class_name_lower_case}_data": 1 }
       # add namespace to class_name
       class_name = "::Pipedrive::#{class_name}" unless class_name.include?("Pipedrive")
-      define_method(resource_name) do
-        response = request(:get, "#{resource_url}/#{resource_name}", options)
+      define_method(resource_name) do |params = {}|
+        response = request(:get,
+                           "#{resource_url}/#{resource_name}",
+                           params.merge(options))
         response.dig(:data)&.map do |data|
           class_name_as_sym = class_name_lower_case.to_sym
           if data.key?(class_name_as_sym)

--- a/lib/pipedrive/version.rb
+++ b/lib/pipedrive/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pipedrive
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end


### PR DESCRIPTION
Recover back the possibility of passing extra parameters to has_many relationships methods, for instance:

```ruby
@organization = Pipedrive::Organization.retrieve(org_id)
@deals = @organization.deals(status: :open) # only those open.
```