### PR TITLE
bugfix - fix: if fields_dicc not set

### DIFF
--- a/lib/pipedrive/resource.rb
+++ b/lib/pipedrive/resource.rb
@@ -33,7 +33,7 @@ module Pipedrive
     end
 
     def self.search_for_fields(values)
-      return values unless values.is_a?(Hash) && fields_dicc.any?
+      return values unless values.is_a?(Hash) && fields_dicc&.any?
 
       values.reduce({}) do |new_hash, (k, v)|
         if inverted_fields_dicc[k]


### PR DESCRIPTION
This was broken if no field are provided.

I don't recall exactly where this happened, but I think it was here: 
```
Pipedrive::Lead.create(title:'new', organization_id: 'some_valid_id')
```

In any case, in other places of the file this is already checked, e.g.
https://github.com/getonbrd/pipedrive-connect/blob/6bd344f32a9c4471a16179eea3a4fd5a550d5896/lib/pipedrive/resource.rb#L32

So this is without a doubt a bug. 