### PR TITLE
Feature - add: api debug info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This file contains all notable changes to this project.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.2.3] - 2021-09-10
+
+- Add `Pipeddrive.debug` so basic debug info is not displayed out of the box.
+- Add `Pipeddrive.debug_http` for debugging http traffic.
+- Fix bug in some resources when no fields filtering was provided.
+
 ## [1.2.2] - 2021-05-11
 
 - Fix bug introduced by v1.2.0 where `has_many` removed the chance to pass extra parameters.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ org.fields
 Pipedrive::Organization.fields
 ```
 
+## Debuging
+
+Show basic debugging info:
+
+```ruby
+Pipedrive.debug = true
+```
+
+show extended HTTP traffic information:
+
+```ruby
+Pipedrive.debug_http = true
+```
+
 ## Development
 
 Run the set up:

--- a/lib/pipedrive.rb
+++ b/lib/pipedrive.rb
@@ -27,7 +27,7 @@ module Pipedrive
   BASE_URL = "https://api.pipedrive.com/v1"
 
   class << self
-    attr_accessor :api_key, :logger
+    attr_accessor :api_key, :logger, :debug_api
   end
 
   @logger = Logger.new(STDOUT)

--- a/lib/pipedrive.rb
+++ b/lib/pipedrive.rb
@@ -27,7 +27,7 @@ module Pipedrive
   BASE_URL = "https://api.pipedrive.com/v1"
 
   class << self
-    attr_accessor :api_key, :logger, :debug_api
+    attr_accessor :api_key, :logger, :debug_http, :debug
   end
 
   @logger = Logger.new(STDOUT)

--- a/lib/pipedrive/api_operations/request.rb
+++ b/lib/pipedrive/api_operations/request.rb
@@ -26,11 +26,9 @@ module Pipedrive
         def api_client
           @api_client = Faraday.new(
             url: BASE_URL,
-            headers: { 'Content-Type': "application/json" }
+            headers: { "Content-Type": "application/json" }
           ) do |faraday|
-            if Pipedrive.debug_api
-              faraday.response :logger
-            end
+            faraday.response :logger if Pipedrive.debug_http
           end
         end
 
@@ -38,7 +36,7 @@ module Pipedrive
           return if Pipedrive.api_key
 
           raise AuthenticationError, "No API key provided. " \
-            "Set your API key using 'Pipedrive.api_key = <API-KEY>'"
+                                     "Set your API key using 'Pipedrive.api_key = <API-KEY>'"
         end
       end
 

--- a/lib/pipedrive/api_operations/request.rb
+++ b/lib/pipedrive/api_operations/request.rb
@@ -27,7 +27,11 @@ module Pipedrive
           @api_client = Faraday.new(
             url: BASE_URL,
             headers: { 'Content-Type': "application/json" }
-          )
+          ) do |faraday|
+            if Pipedrive.debug_api
+              faraday.response :logger
+            end
+          end
         end
 
         protected def check_api_key!

--- a/lib/pipedrive/util.rb
+++ b/lib/pipedrive/util.rb
@@ -19,7 +19,7 @@ module Pipedrive
     end
 
     def self.debug(message)
-      Pipedrive.logger&.debug(message)
+      Pipedrive.logger&.debug(message) if Pipedrive.debug
     end
   end
 end

--- a/lib/pipedrive/version.rb
+++ b/lib/pipedrive/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pipedrive
-  VERSION = "1.2.2"
+  VERSION = "1.2.3"
 end


### PR DESCRIPTION
I needed to debug the http requests, so thought this might be handy.

If ok, the documentation should be extended.

```
# shows the http traffic to/from Pipedrive
Pipedrive.debug_api = true
```

