### PR TITLE
Fix post/put calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ This file contains all notable changes to this project.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.2.4] - 2021-09-13
+
+- Add `Pipedrive.debug_http_body`for debugging the http payload
+- Fix bugs with `POST`/`PUT` endpoints
 ## [1.2.3] - 2021-09-10
 
-- Add `Pipeddrive.debug` so basic debug info is not displayed out of the box.
-- Add `Pipeddrive.debug_http` for debugging http traffic.
+- Add `Pipedrive.debug` so basic debug info is not displayed out of the box.
+- Add `Pipedrive.debug_http` for debugging http traffic.
 - Fix bug in some resources when no fields filtering was provided.
 
 ## [1.2.2] - 2021-05-11

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ show extended HTTP traffic information:
 
 ```ruby
 Pipedrive.debug_http = true
+
+# and to also show the body payloads
+Pipedrive.debug_http_body = true
 ```
 
 ## Development

--- a/lib/pipedrive.rb
+++ b/lib/pipedrive.rb
@@ -27,7 +27,7 @@ module Pipedrive
   BASE_URL = "https://api.pipedrive.com/v1"
 
   class << self
-    attr_accessor :api_key, :logger, :debug_http, :debug
+    attr_accessor :api_key, :logger, :debug, :debug_http, :debug_http_body
   end
 
   @logger = Logger.new(STDOUT)

--- a/lib/pipedrive/version.rb
+++ b/lib/pipedrive/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pipedrive
-  VERSION = "1.2.3"
+  VERSION = "1.2.4"
 end


### PR DESCRIPTION
When creating a lead with an `owner_id´ the current implementation fails.
The reason is that params are sent as url parameters **as well as** body. For some parameters this seems to be tolerated, but for `owner_id` it is not.
The solution is to define the calls properly (if sending data over the body payload, do not add them to the url as well, which will break anyways if is large enough, e.g. when creating a large note)

This PR:
- fixes the post/put problem
- Added a new flag for debugging the http body payload.
- adds documentation and bumps the version