### PR TITLE
Add find method to subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file contains all notable changes to this project.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.2.9] - 2022-10-13
+- Add `find_by_deal` method to `Subscription`to allow finding of subscriptions by `deal_id`.
+
 ## [1.2.8] - 2022-10-11
 
 - Add the new resource `Pipedrive::OrganizationField`

--- a/lib/pipedrive/resources/subscription.rb
+++ b/lib/pipedrive/resources/subscription.rb
@@ -12,6 +12,13 @@ module Pipedrive
       )
       Subscription.new(response.dig(:data))
     end
+    
+    # GET /subscriptions/find/:id
+    # Returns details of a recurring subscription by the deal ID
+    def self.find(id)
+      response = request(:get,"#{resource_url}/find/#{id}")
+      new(response.dig(:data))
+    end
 
     # PUT /subscriptions/recurring/:id
     # Updates a recurring subscription

--- a/lib/pipedrive/resources/subscription.rb
+++ b/lib/pipedrive/resources/subscription.rb
@@ -15,7 +15,7 @@ module Pipedrive
     
     # GET /subscriptions/find/:id
     # Returns details of a recurring subscription by the deal ID
-    def self.find(id)
+    def self.find_by_deal(id)
       response = request(:get,"#{resource_url}/find/#{id}")
       new(response.dig(:data))
     end

--- a/lib/pipedrive/version.rb
+++ b/lib/pipedrive/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pipedrive
-  VERSION = "1.2.8"
+  VERSION = "1.2.9"
 end

--- a/spec/lib/pipedrive/subscription_spec.rb
+++ b/spec/lib/pipedrive/subscription_spec.rb
@@ -41,6 +41,32 @@ RSpec.describe Pipedrive::Subscription, type: :resource do
       end
     end
   end
+  
+  describe "#find" do
+    deal_id = 2
+    before do
+      stubs.get("subscriptions/find/#{deal_id}") do
+        [
+          200,
+          { "Content-Type": "application/json" },
+          {
+            success: true,
+            data: {
+              id: 1,
+              deal_id: deal_id,
+            },
+          }.to_json,
+        ]
+      end
+    end
+
+    it "returns a subscription connected to the deal" do
+      p = described_class.find(deal_id)
+      expect(p).to be_a(Pipedrive::Subscription)
+      expect(p.id).to be(1)
+      expect(p.deal_id).to be(2)
+    end
+  end
 
   describe "#update_recurring" do
     subject { described_class.new(id: 1, name: "My Subscription") }

--- a/spec/lib/pipedrive/subscription_spec.rb
+++ b/spec/lib/pipedrive/subscription_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Pipedrive::Subscription, type: :resource do
     end
   end
   
-  describe "#find" do
+  describe "#find_by_deal" do
     deal_id = 2
     before do
       stubs.get("subscriptions/find/#{deal_id}") do
@@ -61,7 +61,7 @@ RSpec.describe Pipedrive::Subscription, type: :resource do
     end
 
     it "returns a subscription connected to the deal" do
-      p = described_class.find(deal_id)
+      p = described_class.find_by_deal(deal_id)
       expect(p).to be_a(Pipedrive::Subscription)
       expect(p.id).to be(1)
       expect(p.deal_id).to be(2)


### PR DESCRIPTION
Add the [find by deal](https://developers.pipedrive.com/docs/api/v1/Subscriptions#findSubscriptionByDeal) id method to Subscription resource.  Let me know if there are changes you'd like ✌🏼