### PR TITLE
test to recreate response and suggested fix

### DIFF
--- a/lib/pipedrive/api_operations/request.rb
+++ b/lib/pipedrive/api_operations/request.rb
@@ -23,6 +23,8 @@ module Pipedrive
               req.params.merge!(params)
             end
           end
+
+          raise "No item returned" if response.body.empty?
           Util.serialize_response(response)
         end
 

--- a/spec/lib/pipedrive/subscription_spec.rb
+++ b/spec/lib/pipedrive/subscription_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe Pipedrive::Subscription, type: :resource do
   
   describe "#find_by_deal" do
     deal_id = 2
+    deal_with_no_sub_id = 3
+        
     before do
       stubs.get("subscriptions/find/#{deal_id}") do
         [
@@ -58,6 +60,14 @@ RSpec.describe Pipedrive::Subscription, type: :resource do
           }.to_json,
         ]
       end
+      
+      stubs.get("subscriptions/find/#{deal_with_no_sub_id}") do
+        [
+          204,
+          { "Content-Type": "application/json" },
+          "",
+        ]
+      end
     end
 
     it "returns a subscription connected to the deal" do
@@ -65,6 +75,14 @@ RSpec.describe Pipedrive::Subscription, type: :resource do
       expect(p).to be_a(Pipedrive::Subscription)
       expect(p.id).to be(1)
       expect(p.deal_id).to be(2)
+    end
+    
+    it "raises an error if no subscription returned" do
+      expect do
+        p = described_class.find_by_deal(deal_with_no_sub_id)
+      end.to raise_error(
+        "No item returned"
+      )
     end
   end
 


### PR DESCRIPTION
Fixes #23 

Seems odd that the Pipedrive API doesn't return a nice error like when a deal cannot be found. 

Not sure if this is the best way of handling it but the test case reproduces the issue.