### PR TITLE
Override lead to use patch method for updates

### DIFF
--- a/lib/pipedrive/api_operations/request.rb
+++ b/lib/pipedrive/api_operations/request.rb
@@ -11,13 +11,13 @@ module Pipedrive
         def request(method, url, params = {})
           check_api_key!
           raise "Not supported method" \
-            unless %i[get post put delete].include?(method)
+            unless %i[get post put patch delete].include?(method)
 
           Util.debug "#{name} #{method.upcase} #{url}"
           response = api_client.send(method) do |req|
             req.url url
             req.params = { api_token: Pipedrive.api_key }
-            if %i[post put].include?(method)
+            if %i[post put patch].include?(method)
               req.body = params.to_json
             else
               req.params.merge!(params)

--- a/lib/pipedrive/api_operations/update.rb
+++ b/lib/pipedrive/api_operations/update.rb
@@ -5,7 +5,7 @@ module Pipedrive
     module Update
       def update(params)
         response = request(
-          :put,
+          update_method || :put,
           resource_url,
           search_for_fields(params)
         )

--- a/lib/pipedrive/resources/lead.rb
+++ b/lib/pipedrive/resources/lead.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 module Pipedrive
-  class Lead < Resource; end
+  class Lead < Resource
+    update_method :patch
+  end
 end

--- a/spec/lib/pipedrive/lead_spec.rb
+++ b/spec/lib/pipedrive/lead_spec.rb
@@ -6,4 +6,16 @@ RSpec.describe Pipedrive::Lead, type: :resource do
   it "is a Resource" do
     expect(subject).to be_a(Pipedrive::Resource)
   end
+
+  it "overrides the update_method with patch" do
+    expect(subject.update_method).to eq(:patch)
+  end
+
+  it "uses patch method when updating resource" do
+    def subject.id; 1; end
+    expect(Pipedrive::Lead).to receive(:request).with(:patch, anything, anything).and_return({
+      data: {}
+    })
+    subject.update(title: 'ABCDEFG')
+  end
 end


### PR DESCRIPTION
The Lead resource is inconsistent and requires updates to be sent using the :patch method instead of :put.  This PR allows you to override the update method on a resource, and overrides Lead w/ :patch.