### PR TITLE
Update resources available on V2

### DIFF
--- a/lib/pipedrive/resources/deal.rb
+++ b/lib/pipedrive/resources/deal.rb
@@ -8,8 +8,12 @@ module Pipedrive
     has_many :products, class_name: "Product"
     has_many :participants, class_name: "Participant"
 
+    # fields are only available in v1
+    # https://developers.pipedrive.com/docs/api/v1/DealFields#getDealFields
+    use_fields_version :v1
+
     def self.supports_v2_api?
-      false
+      true
     end
   end
 end

--- a/lib/pipedrive/resources/organization.rb
+++ b/lib/pipedrive/resources/organization.rb
@@ -8,5 +8,13 @@ module Pipedrive
     has_many :activities, class_name: "Activity"
     has_many :deals, class_name: "Deal"
     has_many :persons, class_name: "Person"
+
+    # fields are only available in v1
+    # https://developers.pipedrive.com/docs/api/v1/OrganizationFields#getOrganizationFields
+    use_fields_version :v1
+
+    def self.supports_v2_api?
+      true
+    end
   end
 end

--- a/lib/pipedrive/resources/person.rb
+++ b/lib/pipedrive/resources/person.rb
@@ -7,5 +7,13 @@ module Pipedrive
 
     has_many :deals, class_name: "Deal"
     has_many :activities, class_name: "Activity"
+
+    # fields are only available in v1
+    # https://developers.pipedrive.com/docs/api/v1/PersonFields#getPersonFields
+    use_fields_version :v1
+
+    def self.supports_v2_api?
+      true
+    end
   end
 end

--- a/lib/pipedrive/resources/pipeline.rb
+++ b/lib/pipedrive/resources/pipeline.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 module Pipedrive
-  class Pipeline < Resource; end
+  class Pipeline < Resource
+    def self.supports_v2_api?
+      true
+    end
+  end
 end

--- a/lib/pipedrive/resources/product.rb
+++ b/lib/pipedrive/resources/product.rb
@@ -4,8 +4,12 @@ module Pipedrive
   class Product < Resource
     include Fields
 
+    # fields are only available in v1
+    # https://developers.pipedrive.com/docs/api/v1/ProductFields#getProductFields
+    use_fields_version :v1
+
     def self.supports_v2_api?
-      false
+      true
     end
   end
 end

--- a/lib/pipedrive/resources/stage.rb
+++ b/lib/pipedrive/resources/stage.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 module Pipedrive
-  class Stage < Resource; end
+  class Stage < Resource
+    def self.supports_v2_api?
+      true
+    end
+  end
 end

--- a/lib/pipedrive/resources/user.rb
+++ b/lib/pipedrive/resources/user.rb
@@ -18,5 +18,9 @@ module Pipedrive
 
       items.map { |d| new(d) }
     end
+
+    def self.supports_v2_api?
+      true
+    end
   end
 end

--- a/spec/lib/pipedrive/deal_spec.rb
+++ b/spec/lib/pipedrive/deal_spec.rb
@@ -98,14 +98,4 @@ RSpec.describe Pipedrive::Deal, type: :resource do
       expect(subject.delete_product(product_attachment_id)).to be_truthy
     end
   end
-
-  describe "V2 api version" do
-    before do
-      Pipedrive.use_v2_api!
-    end
-
-    it "continues to use V1 endpoint" do
-      expect(described_class.api_version).to eq(:v1)
-    end
-  end
 end


### PR DESCRIPTION
Follow the list of API V2 resources available - https://pipedrive.readme.io/docs/pipedrive-api-v2#api-v2-availability