### PR TITLE
Rollback Deal to version 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [2.1.2] - 2025-08-12
+
+### Fixes
+- Rollback Deal to be back to version **v1**
+
 ## [2.1.1] - 2025-08-06
 
 ### Changed

--- a/lib/pipedrive/resources/deal.rb
+++ b/lib/pipedrive/resources/deal.rb
@@ -13,7 +13,7 @@ module Pipedrive
     use_fields_version :v1
 
     def self.supports_v2_api?
-      true
+      false
     end
   end
 end

--- a/lib/pipedrive/version.rb
+++ b/lib/pipedrive/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pipedrive
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Deal resource now uses the v1 API; v2 support has been disabled.
* **Documentation**
  * Added changelog entry for version 2.1.2 outlining the Deal API rollback.
* **Chores**
  * Bumped version to 2.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->